### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+[![Board Status](https://dev.azure.com/davecoyle02/ff4b57c8-c1de-499a-ab7d-0aea99fced56/1e475fc9-18d8-4bab-83ef-5652457a9998/_apis/work/boardbadge/2210e1ee-b1aa-4d15-81a4-58926512f595)](https://dev.azure.com/davecoyle02/ff4b57c8-c1de-499a-ab7d-0aea99fced56/_boards/board/t/1e475fc9-18d8-4bab-83ef-5652457a9998/Microsoft.RequirementCategory)


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#8](https://dev.azure.com/davecoyle02/ff4b57c8-c1de-499a-ab7d-0aea99fced56/_workitems/edit/8). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.